### PR TITLE
Travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+lex.yy.c
+sac.exe
+sac.tab.c
+sac.tab.h
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 Nokia Solutions and Networks. 
-
+# Copyright (C) 2007 Kokan
 #    This file is part of "Simple ASN.1 Checker".                                   
 #                                                                                   
 #   "Simple ASN.1 Checker" is free software: you can redistribute it and/or modify  
@@ -15,28 +15,9 @@
 #    You should have received a copy of the GNU General Public License              
 #    along with "Simple ASN.1 Checker".  If not, see <http://www.gnu.org/licenses/>.
 
-LEX     = flex
-YACC    = bison
-YFLAGS  = -d
+language: c
 
-SAC_EX=sac.exe
-
-all: $(SAC_EX)
-
-$(SAC_EX) : lex.yy.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $(SAC_EX) lex.yy.c  sac.tab.c parallel.c main.c
-
-lex.yy.c: sac.l sac.tab.c
-	$(LEX)  sac.l
-
-sac.tab.c: sac.y
-	$(YACC) $(YFLAGS) sac.y
-
-clean:
-	$(RM) $(SAC_EX) lex.yy.c sac.tab.c sac.tab.h
-
-test:
-	@echo "Dummy test target"
-
-.PHONY: clean test
+compiler:
+  - clang
+  - gcc
 

--- a/configure
+++ b/configure
@@ -1,5 +1,6 @@
+#!/bin/sh
 # Copyright (C) 2015 Nokia Solutions and Networks. 
-
+# Copyright (C) 2007 Kokan
 #    This file is part of "Simple ASN.1 Checker".                                   
 #                                                                                   
 #   "Simple ASN.1 Checker" is free software: you can redistribute it and/or modify  
@@ -15,28 +16,5 @@
 #    You should have received a copy of the GNU General Public License              
 #    along with "Simple ASN.1 Checker".  If not, see <http://www.gnu.org/licenses/>.
 
-LEX     = flex
-YACC    = bison
-YFLAGS  = -d
-
-SAC_EX=sac.exe
-
-all: $(SAC_EX)
-
-$(SAC_EX) : lex.yy.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $(SAC_EX) lex.yy.c  sac.tab.c parallel.c main.c
-
-lex.yy.c: sac.l sac.tab.c
-	$(LEX)  sac.l
-
-sac.tab.c: sac.y
-	$(YACC) $(YFLAGS) sac.y
-
-clean:
-	$(RM) $(SAC_EX) lex.yy.c sac.tab.c sac.tab.h
-
-test:
-	@echo "Dummy test target"
-
-.PHONY: clean test
+echo "Dummy configure step"
 

--- a/makefile
+++ b/makefile
@@ -15,17 +15,25 @@
 #    You should have received a copy of the GNU General Public License              
 #    along with "Simple ASN.1 Checker".  If not, see <http://www.gnu.org/licenses/>.
 
+LEX     = flex
+YACC    = bison
+YFLAGS  = -d
 
-all:sac.exe
+SAC_EX=sac.exe
 
-sac.exe : lex.yy.c   
-	gcc -o sac.exe lex.yy.c  sac.tab.c parallel.c main.c
+all: $(SAC_EX)
+
+$(SAC_EX) : lex.yy.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $(SAC_EX) lex.yy.c  sac.tab.c parallel.c main.c
 
 lex.yy.c: sac.l sac.tab.c
-	flex  sac.l
-
+	$(LEX)  sac.l
 
 sac.tab.c: sac.y
-	bison -d sac.y
-	
+	$(YACC) $(YFLAGS) sac.y
+
+clean:
+	$(RM) $(SAC_EX) lex.yy.c sac.tab.c sac.tab.h
+
+.PHONY: clean
 


### PR DESCRIPTION
This closes #2 

This contains also a dummy `test` target and a dummy `configure` file.
This is due to the Travis CI executes as a default command for C langaunge:
```bash
./configure && make && make test
```
Those steps are going to have non-dummy implementation. (The readme already has some tips for the `test` target.)

Additionally improved the makefile with standard flags and default variables like CC.

Please update the Travis for this project @CsatariGergely @ror6ax 